### PR TITLE
Fix: stop crashing when retrieving season in progress's game logs

### DIFF
--- a/pro_football_reference_web_scraper/team_game_log.py
+++ b/pro_football_reference_web_scraper/team_game_log.py
@@ -269,38 +269,47 @@ def collect_data(soup: BeautifulSoup, season: int, team: str) -> pd.DataFrame:
             distance_travelled = 0
 
         result = games[i].find('td', {'data-stat': 'game_outcome'}).text
-        points_for = int(games[i].find('td', {'data-stat': 'pts_off'}).text)
-        points_allowed = int(games[i].find('td', {'data-stat': 'pts_def'}).text)
-        tot_yds = (
-            int(games[i].find('td', {'data-stat': 'yards_off'}).text)
-            if games[i].find('td', {'data-stat': 'yards_off'}).text != ''
-            else 0
-        )
-        pass_yds = (
-            int(games[i].find('td', {'data-stat': 'pass_yds_off'}).text)
-            if games[i].find('td', {'data-stat': 'pass_yds_off'}).text != ''
-            else 0
-        )
-        rush_yds = (
-            int(games[i].find('td', {'data-stat': 'rush_yds_off'}).text)
-            if games[i].find('td', {'data-stat': 'rush_yds_off'}).text != ''
-            else 0
-        )
-        opp_tot_yds = (
-            int(games[i].find('td', {'data-stat': 'yards_def'}).text)
-            if games[i].find('td', {'data-stat': 'yards_def'}).text != ''
-            else 0
-        )
-        opp_pass_yds = (
-            int(games[i].find('td', {'data-stat': 'pass_yds_def'}).text)
-            if games[i].find('td', {'data-stat': 'pass_yds_def'}).text != ''
-            else 0
-        )
-        opp_rush_yds = (
-            int(games[i].find('td', {'data-stat': 'rush_yds_def'}).text)
-            if games[i].find('td', {'data-stat': 'pass_yds_def'}).text != ''
-            else 0
-        )
+
+        points_for_text = games[i].find('td', {'data-stat': 'pts_off'}).text
+        if points_for_text.strip():
+            points_for = int(points_for_text)
+        else:
+            points_for = 0
+        points_allowed_text = games[i].find('td', {'data-stat': 'pts_def'}).text
+        if points_allowed_text.strip():
+            points_allowed = int(points_allowed_text)
+        else:
+            points_allowed = 0
+        tot_yds_text = games[i].find('td', {'data-stat': 'yards_off'}).text
+        if tot_yds_text.strip():
+            tot_yds = int(tot_yds_text)
+        else:
+            tot_yds = 0
+        pass_yds_text = games[i].find('td', {'data-stat': 'pass_yds_off'}).text
+        if pass_yds_text.strip():
+            pass_yds = int(pass_yds_text)
+        else:
+            pass_yds = 0
+        rush_yds_text = games[i].find('td', {'data-stat': 'rush_yds_off'}).text
+        if rush_yds_text.strip():
+            rush_yds = int(rush_yds_text)
+        else:
+            rush_yds = 0
+        opp_tot_yds_text = games[i].find('td', {'data-stat': 'yards_def'}).text
+        if opp_tot_yds_text.strip():
+            opp_tot_yds = int(opp_tot_yds_text)
+        else:
+            opp_tot_yds = 0
+        opp_pass_yds_text = games[i].find('td', {'data-stat': 'pass_yds_def'}).text
+        if opp_pass_yds_text.strip():
+            opp_pass_yds = int(opp_pass_yds_text)
+        else:
+            opp_pass_yds = 0
+        opp_rush_yds_text = games[i].find('td', {'data-stat': 'pass_yds_def'}).text
+        if opp_rush_yds_text.strip():
+            opp_rush_yds = int(opp_rush_yds_text)
+        else:
+            opp_rush_yds = 0
 
         # add row to data frame
         df.loc[len(df.index)] = [


### PR DESCRIPTION
## What this does:
No more crash for stat categories with value of 0 for a game -- fixes crash that occurs when getting game logs for season in progress.

## Background:
Was doing some spring cleaning on my older forked repo's, saw this fix was still ahead of this repo, so putting in a pr before nuking my fork.

Sorry if it's irrelevant at this point - please feel free to ignore/deny/close. Or lmk.

